### PR TITLE
Add crypto payments

### DIFF
--- a/components/nft-claim.tsx
+++ b/components/nft-claim.tsx
@@ -1,17 +1,16 @@
 "use client";
 import { useState } from "react";
-import Image from "next/image";
 
 import { NFT_ADDRESS, PAPER_NFT_CONTRACT } from "@/lib/constants";
 import {
   ThirdwebNftMedia,
   useContract,
-  useNFTs,
   usePaperWalletUserEmail,
   useAddress,
   useOwnedNFTs,
   useNFT,
   ConnectWallet,
+  Web3Button
 } from "@thirdweb-dev/react";
 import { useTheme } from "next-themes";
 import { Skeleton } from "./ui/skeleton";
@@ -78,11 +77,18 @@ export function NftClaim() {
           </>
         )}
 
-        {address && email ? (
+        {address ? (
           <div className="flex gap-4">
             <Dialog>
               <DialogTrigger asChild>
-                <Button>Pay With Crypto</Button>
+                <Web3Button
+                  contractAddress={NFT_ADDRESS}
+                  action={async (contract) => {
+                    await contract.erc1155.claim(0, 1)
+                  }}
+                >
+                  Pay With Crypto
+                </Web3Button>
               </DialogTrigger>
               <DialogContent>
                 <DialogHeader>


### PR DESCRIPTION
This is a small addition to add crypto payment support. Below are the primary updates in this PR:

- Added Web3Button for contract interactions to claim
- Removed `email` variable as part of conditional rendering for payment options

The email variable was displaying the logged in state when connecting with Metamask for crypto payments (see image below). 

Removing this in favor of only `address` enables crypto payments and credit card payments will still work. I tested this and the credit card modal will simply ask for your email on checkout if you purchase with CC but log in with Metamask instead of Paper's email option.

![image](https://github.com/ColeMiller21/dakan-poc/assets/56230044/f9c1584a-c178-4e0e-b474-f8b41c2f319c)